### PR TITLE
Write data property sets to instance rather than prototype objects

### DIFF
--- a/src/content/javascript-instrument-page-scope.ts
+++ b/src/content/javascript-instrument-page-scope.ts
@@ -663,9 +663,16 @@ export const pageScript = function() {
             // if accessor property
             returnValue = originalSetter.call(this, value);
           } else if ("value" in propDesc) {
-            // if data property
-            originalValue = value;
+            inLog = true;
+            if (object.isPrototypeOf(this)) {
+              Object.defineProperty(this, propertyName, {
+                value: value
+              });
+            } else {
+              originalValue = value;
+            }
             returnValue = value;
+            inLog = false;
           } else {
             console.error(
               "Property descriptor for",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This fixes #16.It's not the ideal fix, but will prevent this bug from corrupting pages or causing them to stall.


* **What is the current behavior?** (You can also link to an open issue here)

See #16.

* **What is the new behavior (if this is a feature change)?**

When a script overwrites a data property that's been instrumented on a prototype object, the new value should hang off the actual object rather than the prototype. This PR makes this change by setting the new value as a data property on the object. It would be better to set this new value as an accessor property so we can use the same instrumented getters and setters, but that will require a bunch of refactoring.

* **Other information**:

The `inLog` variable acts as a lock so the instrumentation doesn't trigger call logs for the calls it makes itself. In this case, `isPrototypeOf` would result in logged calls if `inLog` wasn't set.