### PR TITLE
Update npm-run-all to remove event-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwpm-webext-instrumentation",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Allows WebExtensions to track and monitor privacy-related browsing behavior",
   "author": "OpenWPM Contributors",
   "license": "GPLv3",
@@ -62,7 +62,7 @@
     "commitizen": "^2.10.1",
     "cz-conventional-changelog": "^2.1.0",
     "gh-pages": "^2.0.0",
-    "npm-run-all": "^4.1.3",
+    "npm-run-all": "^4.1.5",
     "nyc": "^13.0.1",
     "opn-cli": "^3.1.0",
     "prettier": "^1.14.3",


### PR DESCRIPTION
`npm-run-all` depends on `event-stream` which has a known malicious dependency. See https://github.com/dominictarr/event-stream/issues/116 for more information.