### PR TITLE
Added npm run rsync-built-files-to-adjacent-openwpm-repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:tslint": "tslint -t verbose --fix --project .",
+    "rsync-built-files-to-adjacent-openwpm-repo": "rsync -r -t -p -o -g -x --stats --delete -l -D build/ ../OpenWPM/automation/Extension/firefox/node_modules/openwpm-webext-instrumentation/build/",
     "test": "run-s build test:*",
     "test:lint": "tslint -t verbose --project . && prettier \"src/**/*.ts\" --list-different",
     "test:unit": "nyc ava",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

An npm run command for fast syncing of the built files into the OpenWPM extension's node_modules folder, which speeds up testing of modified instrumentation during development. 

* **What is the current behavior?** (You can also link to an open issue here)

Testing changes in the instrumentation requires modifying package.json or using npm link, which conflicts with webpack/typescript module resolution. 

* **What is the new behavior (if this is a feature change)?**

After modifying the instrumentation, one can run `npm run build && npm run rsync-built-files-to-adjacent-openwpm-repo` in the openwpm-webext-instrumentation repo, followed by `./build-extension.sh` in the adjacent OpenWPM repo, to have a local OpenWPM setup that uses the modified instrumentation.