### PR TITLE
Js instrument listen early

### DIFF
--- a/src/background/javascript-instrument.ts
+++ b/src/background/javascript-instrument.ts
@@ -5,63 +5,113 @@ import { boolToInt, escapeString, escapeUrl } from "../lib/string-utils";
 import { JavascriptOperation } from "../schema";
 
 export class JavascriptInstrument {
+  /**
+   * Converts received call and values data from the JS Instrumentation
+   * into the format that the schema expects.
+   * @param data
+   * @param sender
+   */
+  private static processCallsAndValues(data, sender: MessageSender) {
+    const update = {} as JavascriptOperation;
+    update.extension_session_uuid = extensionSessionUuid;
+    update.event_ordinal = incrementedEventOrdinal();
+    update.page_scoped_event_ordinal = data.ordinal;
+    update.window_id = sender.tab.windowId;
+    update.tab_id = sender.tab.id;
+    update.frame_id = sender.frameId;
+    update.script_url = escapeUrl(data.scriptUrl);
+    update.script_line = escapeString(data.scriptLine);
+    update.script_col = escapeString(data.scriptCol);
+    update.func_name = escapeString(data.funcName);
+    update.script_loc_eval = escapeString(data.scriptLocEval);
+    update.call_stack = escapeString(data.callStack);
+    update.symbol = escapeString(data.symbol);
+    update.operation = escapeString(data.operation);
+    update.value = escapeString(data.value);
+    update.time_stamp = data.timeStamp;
+    update.incognito = boolToInt(sender.tab.incognito);
+
+    // document_url is the current frame's document href
+    // top_level_url is the top-level frame's document href
+    update.document_url = escapeUrl(sender.url);
+    update.top_level_url = escapeUrl(sender.tab.url);
+
+    if (data.operation === "call" && data.args.length > 0) {
+      update.arguments = escapeString(JSON.stringify(data.args));
+    }
+
+    return update;
+  }
   private readonly dataReceiver;
   private onMessageListener;
+  private configured: boolean = false;
+  private pendingRecords: JavascriptOperation[] = [];
+  private crawlID;
 
   constructor(dataReceiver) {
     this.dataReceiver = dataReceiver;
   }
 
-  public run(crawlID) {
-    const processCallsAndValues = (data, sender: MessageSender) => {
-      const update = {} as JavascriptOperation;
-      update.crawl_id = crawlID;
-      update.extension_session_uuid = extensionSessionUuid;
-      update.event_ordinal = incrementedEventOrdinal();
-      update.page_scoped_event_ordinal = data.ordinal;
-      update.window_id = sender.tab.windowId;
-      update.tab_id = sender.tab.id;
-      update.frame_id = sender.frameId;
-      update.script_url = escapeUrl(data.scriptUrl);
-      update.script_line = escapeString(data.scriptLine);
-      update.script_col = escapeString(data.scriptCol);
-      update.func_name = escapeString(data.funcName);
-      update.script_loc_eval = escapeString(data.scriptLocEval);
-      update.call_stack = escapeString(data.callStack);
-      update.symbol = escapeString(data.symbol);
-      update.operation = escapeString(data.operation);
-      update.value = escapeString(data.value);
-      update.time_stamp = data.timeStamp;
-      update.incognito = boolToInt(sender.tab.incognito);
-
-      // document_url is the current frame's document href
-      // top_level_url is the top-level frame's document href
-      update.document_url = escapeUrl(sender.url);
-      update.top_level_url = escapeUrl(sender.tab.url);
-
-      if (data.operation === "call" && data.args.length > 0) {
-        update.arguments = escapeString(JSON.stringify(data.args));
-      }
-
-      this.dataReceiver.saveRecord("javascript", update);
-    };
-
-    // Listen for messages from content script injected to instrument JavaScript API
-    this.onMessageListener = (msg, sender) => {
-      // console.debug("javascript-instrumentation background listener - msg, sender, sendReply", msg, sender, sendReply);
-      if (msg.namespace && msg.namespace === "javascript-instrumentation") {
-        switch (msg.type) {
-          case "logCall":
-          case "logValue":
-            processCallsAndValues(msg.data, sender);
-            break;
-        }
+  /**
+   * Start listening for messages from page/content/background scripts injected to instrument JavaScript APIs
+   */
+  public listen() {
+    this.onMessageListener = (message, sender) => {
+      // console.debug("javascript-instrumentation background listener", {message, sender}, this.configured);
+      if (
+        message.namespace &&
+        message.namespace === "javascript-instrumentation"
+      ) {
+        this.handleJsInstrumentationMessage(message, sender);
       }
     };
     browser.runtime.onMessage.addListener(this.onMessageListener);
   }
 
+  /**
+   * Either sends the log data to the dataReceiver or store it in memory
+   * as a pending record if the JS instrumentation is not yet configured
+   * @param message
+   * @param sender
+   */
+  public handleJsInstrumentationMessage(message, sender: MessageSender) {
+    switch (message.type) {
+      case "logCall":
+      case "logValue":
+        const update = JavascriptInstrument.processCallsAndValues(
+          message.data,
+          sender,
+        );
+        if (this.configured) {
+          update.crawl_id = this.crawlID;
+          this.dataReceiver.saveRecord("javascript", update);
+        } else {
+          this.pendingRecords.push(update);
+        }
+        break;
+    }
+  }
+
+  /**
+   * Starts listening if haven't done so already, sets the crawl ID,
+   * marks the JS instrumentation as configured and sends any pending
+   * records that have been received up until this point.
+   * @param crawlID
+   */
+  public run(crawlID) {
+    if (!this.onMessageListener) {
+      this.listen();
+    }
+    this.crawlID = crawlID;
+    this.configured = true;
+    this.pendingRecords.map(update => {
+      update.crawl_id = this.crawlID;
+      this.dataReceiver.saveRecord("javascript", update);
+    });
+  }
+
   public cleanup() {
+    this.pendingRecords = [];
     if (this.onMessageListener) {
       browser.runtime.onMessage.removeListener(this.onMessageListener);
     }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature.

* **What is the current behavior?** (You can also link to an open issue here)

The JS instrument can only be started once a data receiver and crawl id is available. Depending on the mechanics, this may take a while, under which time the JS instrument may already have started to send messages which may end up being dropped / unhandled. 

* **What is the new behavior (if this is a feature change)?**

Allows the JS instrument to listen for messages before the crawl id or data receiver has been configured.
Also exposes handleJsInstrumentationMessage which can be directly invoked in order to handle messages even before any listener is setup, or in cases where the listener is not able to be set up (like within extension background scripts).

(Note: This PR builds upon https://github.com/mozilla/openwpm-webext-instrumentation/pull/42, so please merge that one first and wait for a rebase of this PR before merging.)