### PR TITLE
Return the response body as Uint8Array instead of string

### DIFF
--- a/src/background/http-instrument.ts
+++ b/src/background/http-instrument.ts
@@ -555,7 +555,7 @@ export class HttpInstrument {
       const respBody = await responseBodyListener.getResponseBody();
       const contentHash = await responseBodyListener.getContentHash();
       this.dataReceiver.saveContent(
-        escapeString(respBody),
+        respBody,
         escapeString(contentHash),
       );
       this.dataReceiver.saveRecord("http_responses", update);

--- a/src/background/http-instrument.ts
+++ b/src/background/http-instrument.ts
@@ -558,6 +558,7 @@ export class HttpInstrument {
         respBody,
         escapeString(contentHash),
       );
+      update.content_hash = contentHash;
       this.dataReceiver.saveRecord("http_responses", update);
     } catch (err) {
       /*

--- a/src/lib/response-body-listener.ts
+++ b/src/lib/response-body-listener.ts
@@ -2,9 +2,9 @@ import { WebRequestOnBeforeRequestEventDetails } from "../types/browser-web-requ
 import { sha256Buffer } from "./sha256";
 
 export class ResponseBodyListener {
-  private readonly responseBody: Promise<string>;
+  private readonly responseBody: Promise<Uint8Array>;
   private readonly contentHash: Promise<string>;
-  private resolveResponseBody: (responseBody: string) => void;
+  private resolveResponseBody: (responseBody: Uint8Array) => void;
   private resolveContentHash: (contentHash: string) => void;
 
   constructor(details: WebRequestOnBeforeRequestEventDetails) {
@@ -20,17 +20,22 @@ export class ResponseBodyListener {
       details.requestId,
     ) as any;
 
-    const decoder = new TextDecoder("utf-8");
+    // const decoder = new TextDecoder("utf-8");
     // const encoder = new TextEncoder();
 
-    let responseBody = "";
+    let responseBody = new Uint8Array();
     filter.ondata = event => {
       sha256Buffer(event.data).then(digest => {
         this.resolveContentHash(digest);
       });
-      const str = decoder.decode(event.data, { stream: true });
-      responseBody = responseBody + str;
+      //const str = decoder.decode(event.data, { stream: true });
+      // responseBody = responseBody + str;
       // pass through all the response data
+      const incoming = new Uint8Array(event.data);
+      const tmp = new Uint8Array(responseBody.length + incoming.length);
+      tmp.set(responseBody);
+      tmp.set(incoming, responseBody.length);
+      responseBody = tmp;
       filter.write(event.data);
     };
 

--- a/src/lib/response-body-listener.ts
+++ b/src/lib/response-body-listener.ts
@@ -20,17 +20,11 @@ export class ResponseBodyListener {
       details.requestId,
     ) as any;
 
-    // const decoder = new TextDecoder("utf-8");
-    // const encoder = new TextEncoder();
-
     let responseBody = new Uint8Array();
     filter.ondata = event => {
       sha256Buffer(event.data).then(digest => {
         this.resolveContentHash(digest);
       });
-      //const str = decoder.decode(event.data, { stream: true });
-      // responseBody = responseBody + str;
-      // pass through all the response data
       const incoming = new Uint8Array(event.data);
       const tmp = new Uint8Array(responseBody.length + incoming.length);
       tmp.set(responseBody);


### PR DESCRIPTION
Since the response body might not be a valid utf8 encoded string, the current implementation returns sometimes corrupted strings for binary content. This commit changes the response body type to Uint8Array, which is binary safe.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It's a bugfix but it might also break compatibility since it changes the signature of a method. However I don't think that this can be fixed without potentially breaking compatibility.

* **What is the current behavior?** (You can also link to an open issue here)

Currently, a string containing "\xef\xbf\xbd" for every character that could not be utf8 decoded is returned. This way, the original content is lost and the behaviour is definitely not desired.

* **What is the new behavior (if this is a feature change)?**

A Uint8Array instead of a string is returned now, which can safely handle any binary content.

* **Other information**:

Any code that uses this extension must be updated as well. I will prepare a separate patch for OpenWPM.