### PR TITLE
Handle raw HTTP POST data as well

### DIFF
--- a/src/background/http-instrument.ts
+++ b/src/background/http-instrument.ts
@@ -343,6 +343,9 @@ export class HttpInstrument {
           if ("post_body" in postObj) {
             update.post_body = postObj.post_body;
           }
+          if ("post_body_raw" in postObj) {
+            update.post_body_raw = postObj.post_body_raw;
+          }
         }
       }
     }

--- a/src/lib/http-post-parser.ts
+++ b/src/lib/http-post-parser.ts
@@ -6,11 +6,14 @@ import {
 } from "../types/browser-web-request-event-details";
 // import { escapeString, escapeUrl } from "./string-utils";
 
+import { Uint8ToBase64 } from "./string-utils";
+
 // const components: any = {};
 
 export interface ParsedPostRequest {
   post_headers?: any;
   post_body?: any;
+  post_body_raw?: string;
 }
 
 export class HttpPostParser {
@@ -59,6 +62,12 @@ export class HttpPostParser {
       return {
         // TODO: requestBody.formData should probably be transformed into another format
         post_body: requestBody.formData,
+      };
+    }
+    if (requestBody.raw) {
+      return {
+        post_body_raw: JSON.stringify(requestBody.raw.map(x =>
+          [x.file, Uint8ToBase64(new Uint8Array(x.bytes))])),
       };
     }
 

--- a/src/lib/string-utils.ts
+++ b/src/lib/string-utils.ts
@@ -27,6 +27,22 @@ export const escapeUrl = function(
   return url;
 };
 
+// Base64 encoding, found on:
+// https://stackoverflow.com/questions/12710001/how-to-convert-uint8-array-to-base64-encoded-string/25644409#25644409
+export const Uint8ToBase64 = function(u8Arr: Uint8Array){
+  var CHUNK_SIZE = 0x8000; //arbitrary number
+  var index = 0;
+  var length = u8Arr.length;
+  var result = '';
+  var slice: Uint8Array;
+  while (index < length) {
+    slice = u8Arr.subarray(index, Math.min(index + CHUNK_SIZE, length));
+    result += String.fromCharCode.apply(null, slice);
+    index += CHUNK_SIZE;
+  }
+  return btoa(result);
+}
+
 export const boolToInt = function(bool: boolean) {
   return bool ? 1 : 0;
 };

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -68,6 +68,7 @@ export interface HttpRequest {
   req_call_stack?: string;
   resource_type: string;
   post_body?: string;
+  post_body_raw?: string;
   time_stamp: DateTime;
 }
 


### PR DESCRIPTION
In case that the HTTP POST data cannot be parsed as formData, it is also possible to access it as raw binary data. This was previously not supported by the extension and no HTTP POST data was logged for HTTP POST requests that failed to parse as formData by Firefox. This commit handles those cases as well.

The data is made available by Firefox as a list of 2-touples of filename - content pairs. The content is presented in a binary form. Since that content might not represent a valid utf8 string, a base64 encoding is applied so that the content is finally exported as a JSON encoded string.

This requires that the receiving code expects a new field named *post_body_raw*.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix, with that PR, HTTP POST data that cannot be parsed as formData is handled as well.

* **What is the current behavior?** (You can also link to an open issue here)

The data is simply lost.

* **What is the new behavior (if this is a feature change)?**

The data is saved in a new row named post_body_raw that contains a JSON encoded list of 2-touples. The first entry is a filename and the second entry is the raw data base64 encoded.

* **Other information**:
